### PR TITLE
Improve the email link naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
 	</li>
 
         <li>
-            Notify: <a
+            Email list for event notifications: <a
                 title="This is best way to get notify of next meeting"
-                href="https://groups.google.com/d/forum/pgug-ee">Google Group "mailing list"</a>
+                href="https://groups.google.com/d/forum/pgug-ee">Google Groups</a>
         <li>Discuss: <a
                 title="casual talk goes here"
                 href="https://www.facebook.com/groups/pgug.ee/">Facebook Group</a>


### PR DESCRIPTION
People couldn't find the link seems